### PR TITLE
VIO-1911 Bump up to ci-shared tag 1.20.1

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library identifier: 'vapor@1.20.0', retriever: modernSCM([
+library identifier: 'vapor@1.20.1', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
   credentialsId: 'vio-bot-gh',


### PR DESCRIPTION
Bump up to ci-shared tag 1.20.1 to pull in fixes from https://github.com/vapor-ware/ci-shared/pull/193